### PR TITLE
Introduce groups

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,9 +1,15 @@
 {
   "version": "2",
-  "remote": {},
+  "remote": {
+    "https://deno.land/std@0.177.0/fmt/colors.ts": "938c5d44d889fb82eff6c358bea8baa7e85950a16c9f6dae3ec3a7a729164471",
+    "https://deno.land/std@0.177.0/testing/_diff.ts": "1a3c044aedf77647d6cac86b798c6417603361b66b54c53331b312caeb447aea",
+    "https://deno.land/std@0.177.0/testing/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://deno.land/std@0.177.0/testing/asserts.ts": "984ab0bfb3faeed92ffaa3a6b06536c66811185328c5dd146257c702c41b01ab"
+  },
   "npm": {
     "specifiers": {
       "@cosmjs/cosmwasm-stargate": "@cosmjs/cosmwasm-stargate@0.29.5",
+      "@cosmjs/crypto": "@cosmjs/crypto@0.29.5",
       "@cosmjs/encoding": "@cosmjs/encoding@0.29.5",
       "@cosmjs/math": "@cosmjs/math@0.29.5",
       "@cosmjs/proto-signing": "@cosmjs/proto-signing@0.29.5",

--- a/group.ts
+++ b/group.ts
@@ -1,0 +1,17 @@
+import { sha256 } from "npm:@cosmjs/crypto";
+import { toUtf8 } from "npm:@cosmjs/encoding";
+
+export function group(address: string): "A" | "B" {
+  const hash = sha256(toUtf8(address))[0];
+  if (hash % 2 == 0) return "A";
+  else return "B";
+}
+
+export function eligibleGroup(round: number): "A" | "B" {
+  if (round % 2 == 0) return "A";
+  else return "B";
+}
+
+export function isMyGroup(address: string, round: number): boolean {
+  return eligibleGroup(round) == group(address);
+}

--- a/group_test.ts
+++ b/group_test.ts
@@ -1,0 +1,19 @@
+import { assertEquals } from "https://deno.land/std@0.177.0/testing/asserts.ts";
+import { eligibleGroup, group } from "./group.ts";
+
+Deno.test("group works", () => {
+  assertEquals(group("nois1ffy2rz96sjxzm2ezwkmvyeupktp7elt6w3xckt"), "B");
+  assertEquals(group("nois1uw8c69maprjq5ure7x80x9nauasrn7why5dfwd"), "B");
+  assertEquals(group("nois1zh77twxfc47eu59q7mc7027jvvcnrpte3sr922"), "B");
+  assertEquals(group("nois1wpy3gwlw4tt3uy0u5jrspfz0w9azztvlr0d04s"), "A");
+  assertEquals(group("nois1rw47dxvhw3ahdlcznvwpcz43cdq8l0832eg6re"), "A");
+  assertEquals(group("nois12a8yv4ndgnkygujj7cmmkfz2j9wjanezldwye0"), "B");
+});
+
+Deno.test("eligibleGroup works", () => {
+  assertEquals(eligibleGroup(1), "B");
+  assertEquals(eligibleGroup(2), "A");
+  assertEquals(eligibleGroup(3), "B");
+  assertEquals(eligibleGroup(4), "A");
+  assertEquals(eligibleGroup(5), "B");
+});


### PR DESCRIPTION
Submission groups split the bots in two groups A and B. Every group submits only even or only odd rounds.

<img width="1209" alt="Bildschirmfoto 2023-02-07 um 23 12 29" src="https://user-images.githubusercontent.com/2603011/217378949-06544973-cae1-48cf-a5ec-8ef0c66d2733.png">
